### PR TITLE
rootdir: Add back sensorservice

### DIFF
--- a/rootdir/etc/init.ubuntu.rc
+++ b/rootdir/etc/init.ubuntu.rc
@@ -1,6 +1,7 @@
 on early-boot
     start miniafservice
     start init_wlan_bt
+    start sensorservice
 
 service init_wlan_bt /system/bin/sh /system/etc/init_hcismd_up.sh
     class main
@@ -12,3 +13,7 @@ service miniafservice /system/bin/miniafservice
     class core
     user root
     group audio
+
+service sensorservice /system/bin/sensorservice
+    class main
+    user root


### PR DESCRIPTION
* Android side kills this anyway, but it fixes the enormous amounts of logspam about sensorservice not being started.